### PR TITLE
Listen to client errors to avoid application exiting

### DIFF
--- a/src/adapters/redis.ts
+++ b/src/adapters/redis.ts
@@ -25,6 +25,10 @@ class RedisContext implements IRedisContext {
       this.redisClient = createClient({ url })
       this.redisClient.connect()
       logger.info('Connected to Redis successfully!')
+
+      this.redisClient.on('error', (error) => {
+        logger.error(error)
+      })
     } catch (e) {
       this.redisClient = null
       logger.info('Unable to connect to Redis!')


### PR DESCRIPTION
This adds a logger in case of errors to avoid the application to exit when errors such as "Socket Closed Unexpectedly" happens, instead, keeps it on the logger the issue.